### PR TITLE
adding statcounter as web statistics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,4 +25,22 @@
 
 </body>
 
+<!-- Default Statcounter code for LuLab
+https://plantgeneticslab.github.io/home/ -->
+<script type="text/javascript">
+var sc_project=12732004; 
+var sc_invisible=1; 
+var sc_security="d1536717"; 
+</script>
+<script type="text/javascript"
+src="https://www.statcounter.com/counter/counter.js"
+async></script>
+<noscript><div class="statcounter"><a title="web counter"
+href="https://statcounter.com/" target="_blank"><img
+class="statcounter"
+src="https://c.statcounter.com/12732004/0/d1536717/1/"
+alt="web counter"
+referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+<!-- End of Statcounter Code -->
+
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,5 +20,23 @@
     {{ content }}
 
     </body>
+    
+<!-- Default Statcounter code for LuLab
+https://plantgeneticslab.github.io/home/ -->
+<script type="text/javascript">
+var sc_project=12732004; 
+var sc_invisible=1; 
+var sc_security="d1536717"; 
+</script>
+<script type="text/javascript"
+src="https://www.statcounter.com/counter/counter.js"
+async></script>
+<noscript><div class="statcounter"><a title="web counter"
+href="https://statcounter.com/" target="_blank"><img
+class="statcounter"
+src="https://c.statcounter.com/12732004/0/d1536717/1/"
+alt="web counter"
+referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+<!-- End of Statcounter Code -->
 
 </html>

--- a/_layouts/journal_by_tag.html
+++ b/_layouts/journal_by_tag.html
@@ -33,3 +33,21 @@ header-img: "img/misc-bg.jpg"
         <p>There are no posts for this tag.</p>
     {% endif %}
 </div>
+
+<!-- Default Statcounter code for LuLab
+https://plantgeneticslab.github.io/home/ -->
+<script type="text/javascript">
+var sc_project=12732004; 
+var sc_invisible=1; 
+var sc_security="d1536717"; 
+</script>
+<script type="text/javascript"
+src="https://www.statcounter.com/counter/counter.js"
+async></script>
+<noscript><div class="statcounter"><a title="web counter"
+href="https://statcounter.com/" target="_blank"><img
+class="statcounter"
+src="https://c.statcounter.com/12732004/0/d1536717/1/"
+alt="web counter"
+referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+<!-- End of Statcounter Code -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,3 +33,21 @@ layout: default
 
 <!-- Custom Theme JavaScript -->
 <!--<script src="{{ site.baseurl }}/js/main.min.js "></script>-->
+
+<!-- Default Statcounter code for LuLab
+https://plantgeneticslab.github.io/home/ -->
+<script type="text/javascript">
+var sc_project=12732004; 
+var sc_invisible=1; 
+var sc_security="d1536717"; 
+</script>
+<script type="text/javascript"
+src="https://www.statcounter.com/counter/counter.js"
+async></script>
+<noscript><div class="statcounter"><a title="web counter"
+href="https://statcounter.com/" target="_blank"><img
+class="statcounter"
+src="https://c.statcounter.com/12732004/0/d1536717/1/"
+alt="web counter"
+referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+<!-- End of Statcounter Code -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -226,6 +226,26 @@ image: {
  <script src="{{ site.baseurl }}/js/modernizr.js"></script>
 
 </body>
+
+<!-- Default Statcounter code for LuLab
+https://plantgeneticslab.github.io/home/ -->
+<script type="text/javascript">
+var sc_project=12732004; 
+var sc_invisible=1; 
+var sc_security="d1536717"; 
+</script>
+<script type="text/javascript"
+src="https://www.statcounter.com/counter/counter.js"
+async></script>
+<noscript><div class="statcounter"><a title="web counter"
+href="https://statcounter.com/" target="_blank"><img
+class="statcounter"
+src="https://c.statcounter.com/12732004/0/d1536717/1/"
+alt="web counter"
+referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+<!-- End of Statcounter Code -->
+
+
 </html>
 
 


### PR DESCRIPTION
"<!-- Default Statcounter code for LuLab
https://plantgeneticslab.github.io/home/ -->
<script type="text/javascript">
var sc_project=12732004; 
var sc_invisible=1; 
var sc_security="d1536717"; 
</script>
<script type="text/javascript"
src="https://www.statcounter.com/counter/counter.js"
async></script>
<noscript><div class="statcounter"><a title="web counter"
href="https://statcounter.com/" target="_blank"><img
class="statcounter"
src="https://c.statcounter.com/12732004/0/d1536717/1/"
alt="web counter"
referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
<!-- End of Statcounter Code -->"

I've add this code into layouts as our website statistics to count and track visitor records.